### PR TITLE
[CLD-1] FEATURE: Github -> Jira 이슈 동기화

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,38 @@
+name: Epic
+description: Track company-wide initiatives or multi-sprint work
+labels:
+  - Epic
+projects:
+  - ddcn4-1/10
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: 목표 기능 내용
+      description: Epic의 목표와 달성하고자 하는 기능을 설명해주세요.
+      placeholder: "예) 사용자가 소셜 로그인을 통해 간편하게 회원가입 및 로그인할 수 있도록 합니다."
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: 작업 상세 내용
+      description: Epic을 구성하는 세부 작업들을 나열해주세요.
+      placeholder: |
+        - [ ] Task 1: 구글 OAuth 연동
+        - [ ] Task 2: 카카오 OAuth 연동
+        - [ ] Task 3: 소셜 로그인 UI 구현
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: 관련 문서, 이슈, 또는 참고 자료의 링크를 추가해주세요.
+      placeholder: |
+        - 관련 이슈: #123
+        - 참고 문서: https://...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task_1_feature.yml
+++ b/.github/ISSUE_TEMPLATE/task_1_feature.yml
@@ -1,0 +1,40 @@
+name: Task - Feature
+description: Standard work item when no specialized template fits
+title: "FEATURE: "
+labels:
+  - Task
+  - feature
+projects:
+  - ddcn4-1/10
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: 목표 기능 내용
+      description: 구현하고자 하는 기능을 설명해주세요.
+      placeholder: "예) 로그인 시, 구글 소셜 로그인 기능을 추가합니다."
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: 작업 상세 내용
+      description: 구체적인 작업 내용과 구현 방법을 설명해주세요.
+      placeholder: |
+        - OAuth 2.0 인증 흐름 구현
+        - 사용자 정보 연동
+        - 에러 처리
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: 관련 문서, 이슈, 또는 참고 자료의 링크를 추가해주세요.
+      placeholder: |
+        - 관련 이슈: #123
+        - API 문서: https://...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task_2_refactor.yml
+++ b/.github/ISSUE_TEMPLATE/task_2_refactor.yml
@@ -1,0 +1,40 @@
+name: Task - Refactor
+description: Use for codebase or architecture improvements
+title: "REFACTOR: "
+labels:
+  - Task
+  - refactor
+projects:
+  - ddcn4-1/10
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: 목표 리팩토링 내용
+      description: 리팩토링하고자 하는 영역과 목적을 설명해주세요.
+      placeholder: "예) 사용자 인증 모듈의 복잡도를 낮추고 테스트 가능성을 개선합니다."
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: 작업 상세 내용
+      description: 구체적인 개선 사항과 예상 효과를 설명해주세요.
+      placeholder: |
+        - 현재 문제점: 중복 코드, 높은 복잡도
+        - 개선 방안: 공통 함수 추출, 책임 분리
+        - 예상 효과: 유지보수성 향상, 테스트 커버리지 증가
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: 관련 문서나 참고 자료의 링크를 추가해주세요.
+      placeholder: |
+        - 관련 이슈: #123
+        - 설계 문서: https://...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task_3_chore.yml
+++ b/.github/ISSUE_TEMPLATE/task_3_chore.yml
@@ -1,0 +1,40 @@
+name: Task - Chore
+description: Tooling, maintenance, or operational chores
+title: "CHORE: "
+labels:
+  - Task
+  - chore
+projects:
+  - ddcn4-1/10
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: 목표 작업 내용
+      description: 수행하고자 하는 유지보수 작업을 설명해주세요.
+      placeholder: "예) GitHub Actions 워크플로우 러너를 최신 버전으로 업그레이드합니다."
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: 작업 상세 내용
+      description: 구체적인 작업 내용과 예상 결과를 설명해주세요.
+      placeholder: |
+        - 현재 버전: ubuntu-20.04
+        - 목표 버전: ubuntu-22.04
+        - 변경 영향도: 빌드 속도 개선 예상
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: 관련 문서나 참고 자료의 링크를 추가해주세요.
+      placeholder: |
+        - 변경 사항: https://...
+        - 관련 이슈: #123
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task_4_docs.yml
+++ b/.github/ISSUE_TEMPLATE/task_4_docs.yml
@@ -1,0 +1,41 @@
+name: Task - Docs
+description: Documentation updates, READMEs, or runbooks
+title: "DOCS: "
+labels:
+  - Task
+  - docs
+projects:
+  - ddcn4-1/10
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: 목표 문서 작업
+      description: 작성하거나 수정하고자 하는 문서를 설명해주세요.
+      placeholder: "예) API 사용 가이드 문서를 작성합니다."
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: 작업 상세 내용
+      description: 문서의 주요 섹션과 내용을 설명해주세요.
+      placeholder: |
+        - 개요 섹션
+        - 설치 가이드
+        - API 레퍼런스
+        - 예제 코드
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: 관련 문서나 참고 자료의 링크를 추가해주세요.
+      placeholder: |
+        - 기존 문서: https://...
+        - 참고 자료: https://...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task_5_bug.yml
+++ b/.github/ISSUE_TEMPLATE/task_5_bug.yml
@@ -1,0 +1,59 @@
+name: Task - Bug
+description: Report a defect that still maps to a Jira Task
+title: "BUG: "
+labels:
+  - Task
+  - bug
+projects:
+  - ddcn4-1/10
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 버그 설명
+      description: 발생한 버그에 대해 설명해주세요.
+      placeholder: "예) 로그인 버튼 클릭 시 페이지가 응답하지 않습니다."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: 재현 방법
+      description: 버그를 재현할 수 있는 단계를 설명해주세요.
+      placeholder: |
+        1. 로그인 페이지로 이동
+        2. 이메일과 비밀번호 입력
+        3. 로그인 버튼 클릭
+        4. 에러 발생
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 예상 동작
+      description: 정상적으로 동작해야 하는 방식을 설명해주세요.
+      placeholder: "로그인 성공 후 대시보드 페이지로 이동해야 합니다."
+    validations:
+      required: false
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 실제 동작
+      description: 실제로 발생하는 동작을 설명해주세요.
+      placeholder: "페이지가 멈추고 콘솔에 에러가 출력됩니다."
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: 스크린샷, 로그, 또는 관련 자료를 추가해주세요.
+      placeholder: |
+        - 에러 로그: ```error message```
+        - 스크린샷: [이미지 첨부]
+    validations:
+      required: false

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "jira-sync-scripts",
+  "version": "0.1.0",
+  "description": "GitHub Actions scripts for Jira synchronization",
+  "type": "module",
+  "dependencies": {
+    "jira-client": "^8.2.2"
+  }
+}

--- a/.github/scripts/sync-comment-to-jira.js
+++ b/.github/scripts/sync-comment-to-jira.js
@@ -1,0 +1,195 @@
+import JiraClient from "jira-client";
+
+/**
+ * GitHub Comment를 Jira Comment로 동기화하는 스크립트
+ */
+
+// 환경 변수 검증
+function validateEnv() {
+  const required = [
+    "JIRA_HOST",
+    "JIRA_EMAIL",
+    "JIRA_API_TOKEN",
+    "JIRA_PROJECT_KEY",
+    "GITHUB_EVENT_ACTION",
+    "GITHUB_COMMENT_ID",
+    "GITHUB_COMMENT_BODY",
+    "GITHUB_COMMENT_USER",
+    "GITHUB_ISSUE_NUMBER",
+    "GITHUB_ISSUE_TITLE",
+    "GITHUB_REPOSITORY_NAME",
+  ];
+
+  const missing = required.filter((key) => !process.env[key]);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(", ")}`
+    );
+  }
+}
+
+// Jira 클라이언트 초기화
+function initJiraClient() {
+  return new JiraClient({
+    protocol: "https",
+    host: process.env.JIRA_HOST,
+    username: process.env.JIRA_EMAIL,
+    password: process.env.JIRA_API_TOKEN,
+    apiVersion: "2",
+    strictSSL: true,
+  });
+}
+
+// GitHub Issue 제목에서 Jira Key 추출
+function extractJiraKeyFromTitle(title) {
+  const match = title.match(/\[([A-Z]+-\d+)\]/);
+  return match ? match[1] : null;
+}
+
+// GitHub Comment에서 Jira Comment 본문 생성
+function buildJiraCommentBody() {
+  const commentId = process.env.GITHUB_COMMENT_ID;
+  const commentBody = process.env.GITHUB_COMMENT_BODY;
+  const commentUser = process.env.GITHUB_COMMENT_USER;
+  const commentUserUrl = process.env.GITHUB_COMMENT_USER_URL;
+  const commentUrl = process.env.GITHUB_COMMENT_HTML_URL;
+
+  // Jira Comment ID 마커 (편집 시 찾기 위함)
+  const marker = `{panel:borderStyle=none|bgColor=#f4f5f7}GitHub Comment ID: ${commentId}{panel}`;
+
+  // 본문 구성
+  let body = `${marker}\n\n`;
+  body += `*작성자:* [${commentUser}|${commentUserUrl}]\n`;
+  body += `*GitHub:* [View Comment|${commentUrl}]\n\n`;
+  body += `{quote}${commentBody}{quote}`;
+
+  return body;
+}
+
+// Jira Comment 검색 (GitHub Comment ID로)
+async function findJiraCommentByGithubId(jira, issueKey, githubCommentId) {
+  try {
+    const comments = await jira.getComments(issueKey);
+
+    if (!comments || !comments.comments) {
+      return null;
+    }
+
+    // GitHub Comment ID 마커가 포함된 코멘트 찾기
+    const marker = `GitHub Comment ID: ${githubCommentId}`;
+    const jiraComment = comments.comments.find(
+      (c) => c.body && c.body.includes(marker)
+    );
+
+    return jiraComment || null;
+  } catch (error) {
+    console.error("Jira 코멘트 검색 실패:", error.message);
+    return null;
+  }
+}
+
+// GitHub Comment 생성 처리
+async function handleCommentCreated(jira, jiraKey) {
+  console.log("=== GitHub 코멘트 생성 - Jira에 코멘트 추가 ===");
+
+  const commentBody = buildJiraCommentBody();
+
+  try {
+    await jira.addComment(jiraKey, commentBody);
+    console.log(`✅ Jira 코멘트 추가 성공: ${jiraKey}`);
+  } catch (error) {
+    console.error("❌ Jira 코멘트 추가 실패:", error.message);
+    throw error;
+  }
+}
+
+// GitHub Comment 편집 처리
+async function handleCommentEdited(jira, jiraKey) {
+  console.log("=== GitHub 코멘트 편집 - Jira 코멘트 업데이트 ===");
+
+  const githubCommentId = process.env.GITHUB_COMMENT_ID;
+
+  // 기존 Jira 코멘트 찾기
+  const existingComment = await findJiraCommentByGithubId(
+    jira,
+    jiraKey,
+    githubCommentId
+  );
+
+  if (!existingComment) {
+    console.log(
+      "⚠️  기존 Jira 코멘트를 찾을 수 없습니다. 새 코멘트를 추가합니다."
+    );
+    await handleCommentCreated(jira, jiraKey);
+    return;
+  }
+
+  console.log(`찾은 Jira 코멘트 ID: ${existingComment.id}`);
+
+  const commentBody = buildJiraCommentBody();
+
+  try {
+    await jira.updateComment(jiraKey, existingComment.id, commentBody);
+    console.log(`✅ Jira 코멘트 업데이트 성공: ${jiraKey}`);
+  } catch (error) {
+    console.error("❌ Jira 코멘트 업데이트 실패:", error.message);
+    throw error;
+  }
+}
+
+// 메인 실행
+async function main() {
+  try {
+    console.log("🚀 GitHub Comment to Jira 동기화 시작");
+    console.log("Event Action:", process.env.GITHUB_EVENT_ACTION);
+    console.log("Comment ID:", process.env.GITHUB_COMMENT_ID);
+    console.log("Issue Number:", process.env.GITHUB_ISSUE_NUMBER);
+    console.log("Issue Title:", process.env.GITHUB_ISSUE_TITLE);
+
+    // 환경 변수 검증
+    validateEnv();
+
+    // GitHub Issue 제목에서 Jira Key 추출
+    const jiraKey = extractJiraKeyFromTitle(process.env.GITHUB_ISSUE_TITLE);
+
+    if (!jiraKey) {
+      console.log(
+        "⚠️  Issue 제목에서 Jira Key를 찾을 수 없습니다. 동기화를 건너뜁니다."
+      );
+      console.log("Note: Jira Key는 '[JST-123]' 형식으로 제목에 포함되어야 합니다.");
+      process.exit(0);
+    }
+
+    console.log(`추출된 Jira Key: ${jiraKey}`);
+
+    // Jira 클라이언트 초기화
+    const jira = initJiraClient();
+
+    // 이벤트 타입별 처리
+    switch (process.env.GITHUB_EVENT_ACTION) {
+      case "created":
+        await handleCommentCreated(jira, jiraKey);
+        break;
+
+      case "edited":
+        await handleCommentEdited(jira, jiraKey);
+        break;
+
+      default:
+        console.log(
+          `⚠️  처리되지 않는 이벤트: ${process.env.GITHUB_EVENT_ACTION}`
+        );
+    }
+
+    console.log("✅ Comment 동기화 완료");
+    process.exit(0);
+  } catch (error) {
+    console.error("❌ Comment 동기화 실패:", error.message);
+    console.error(error.stack);
+    process.exit(1);
+  }
+}
+
+// 스크립트 실행
+main();

--- a/.github/scripts/sync-jira.js
+++ b/.github/scripts/sync-jira.js
@@ -1,0 +1,1039 @@
+import JiraClient from "jira-client";
+import fs from "fs";
+
+/**
+ * GitHub Actions용 Jira 동기화 스크립트
+ * 환경 변수를 통해 GitHub 이벤트 정보를 받아 Jira와 동기화
+ */
+
+// 환경 변수 검증
+function validateEnv() {
+  const required = [
+    "JIRA_HOST",
+    "JIRA_EMAIL",
+    "JIRA_API_TOKEN",
+    "JIRA_PROJECT_KEY",
+    "GITHUB_EVENT_ACTION",
+    "GITHUB_ISSUE_NUMBER",
+  ];
+
+  const missing = required.filter((key) => !process.env[key]);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(", ")}`
+    );
+  }
+}
+
+// Jira 클라이언트 초기화
+function initJiraClient() {
+  return new JiraClient({
+    protocol: "https",
+    host: process.env.JIRA_HOST,
+    username: process.env.JIRA_EMAIL,
+    password: process.env.JIRA_API_TOKEN,
+    apiVersion: "2",
+    strictSSL: true,
+  });
+}
+
+// GitHub 라벨에서 우선순위 결정
+function determinePriority(labelsJson) {
+  try {
+    const labels = JSON.parse(labelsJson || "[]");
+    const labelNames = labels.map((l) => l.name.toLowerCase());
+
+    if (labelNames.some((l) => ["critical", "urgent"].includes(l))) {
+      return "Highest";
+    }
+    if (labelNames.some((l) => ["high", "important"].includes(l))) {
+      return "High";
+    }
+    if (labelNames.includes("low")) {
+      return "Low";
+    }
+
+    return process.env.JIRA_DEFAULT_PRIORITY || "Medium";
+  } catch (error) {
+    console.log("라벨 파싱 실패, 기본 우선순위 사용:", error.message);
+    return process.env.JIRA_DEFAULT_PRIORITY || "Medium";
+  }
+}
+
+// GitHub 라벨을 Jira 라벨로 변환
+function convertLabels(labelsJson) {
+  try {
+    const labels = JSON.parse(labelsJson || "[]");
+    return labels.map((l) => l.name.toLowerCase().replace(/\s+/g, "-"));
+  } catch (error) {
+    console.log("라벨 변환 실패:", error.message);
+    return [];
+  }
+}
+
+const ISSUE_TYPE_SYNONYMS = {
+  Epic: ["Epic", "에픽"],
+  Task: ["Task", "작업"],
+};
+
+// 이슈 타입 매핑 (GitHub 라벨 → Jira 이슈 타입)
+function mapIssueTypeToJira(githubType) {
+  // 기본적으로 영문 사용
+  const englishMapping = {
+    Epic: "Epic",
+    Task: "Task",
+    Subtask: "Subtask",
+  };
+
+  // 한글 프로젝트용
+  const koreanMapping = {
+    Epic: "에픽",
+    Task: "작업",
+    Subtask: "하위 작업",
+  };
+
+  const useKorean = process.env.JIRA_USE_KOREAN_ISSUE_TYPES === "true";
+  const mapping = useKorean ? koreanMapping : englishMapping;
+
+  return mapping[githubType] || githubType;
+}
+
+function normalizeIssueTypeName(name) {
+  return (name || "").trim().toLowerCase();
+}
+
+function isEpicTypeName(name) {
+  const normalized = normalizeIssueTypeName(name);
+  return ISSUE_TYPE_SYNONYMS.Epic.some(
+    (alias) => normalizeIssueTypeName(alias) === normalized
+  );
+}
+
+function isTaskTypeName(name) {
+  const normalized = normalizeIssueTypeName(name);
+  return ISSUE_TYPE_SYNONYMS.Task.some(
+    (alias) => normalizeIssueTypeName(alias) === normalized
+  );
+}
+
+function resolveIssueTypeName(preferredName, availableTypes = []) {
+  if (!preferredName) {
+    return preferredName;
+  }
+
+  const normalizedPreferred = normalizeIssueTypeName(preferredName);
+
+  const exactMatch = availableTypes.find(
+    (type) => normalizeIssueTypeName(type.name) === normalizedPreferred
+  );
+  if (exactMatch) {
+    return exactMatch.name;
+  }
+
+  const synonyms = isEpicTypeName(preferredName)
+    ? ISSUE_TYPE_SYNONYMS.Epic
+    : isTaskTypeName(preferredName)
+    ? ISSUE_TYPE_SYNONYMS.Task
+    : [preferredName];
+
+  for (const synonym of synonyms) {
+    const match = availableTypes.find(
+      (type) =>
+        normalizeIssueTypeName(type.name) === normalizeIssueTypeName(synonym)
+    );
+    if (match) {
+      return match.name;
+    }
+  }
+
+  return preferredName;
+}
+
+// GitHub 이슈 본문에서 Epic Link 파싱
+function parseEpicLinkFromBody(issueBody) {
+  if (!issueBody) {
+    return null;
+  }
+
+  // Epic Link 패턴 매칭
+  const patterns = [
+    // ### Epic Link\nJST-123
+    /###\s*Epic\s*Link\s*\n+([A-Z]+-\d+)/i,
+    // **Epic Link:** JST-123
+    /\*\*Epic\s*Link:\*\*\s*([A-Z]+-\d+)/i,
+    // Epic Link: JST-123
+    /Epic\s*Link:\s*([A-Z]+-\d+)/i,
+    // GitHub issue reference: #45
+    /###\s*Epic\s*Link\s*\n+#(\d+)/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = issueBody.match(pattern);
+    if (match && match[1]) {
+      const epicRef = match[1].trim();
+      console.log(`✓ Epic Link 파싱 성공: "${epicRef}"`);
+      return epicRef;
+    }
+  }
+
+  console.log("✗ Epic Link를 찾을 수 없음");
+  return null;
+}
+
+// GitHub 이슈 제목/본문에서 Jira Key 추출 ([JST-123] 형식)
+function extractJiraKeyFromText(text) {
+  if (!text) {
+    return null;
+  }
+
+  const match = text.match(/\[([A-Z][A-Z0-9_-]+-\d+)\]/i);
+  if (match && match[1]) {
+    const key = match[1].toUpperCase();
+    console.log(`✓ 텍스트에서 Jira Key 추출: ${key}`);
+    return key;
+  }
+
+  return null;
+}
+
+// Jira JQL 검색 (POST /rest/api/3/search/jql)
+async function searchJiraIssues(jql, { maxResults = 50 } = {}) {
+  const host = process.env.JIRA_HOST;
+  const email = process.env.JIRA_EMAIL;
+  const token = process.env.JIRA_API_TOKEN;
+
+  if (!host || !email || !token) {
+    throw new Error(
+      "Jira 인증 정보(JIRA_HOST, JIRA_EMAIL, JIRA_API_TOKEN)가 필요합니다."
+    );
+  }
+
+  const baseUrl = host.startsWith("http")
+    ? host.replace(/\/$/, "")
+    : `https://${host}`.replace(/\/$/, "");
+  const url = `${baseUrl}/rest/api/3/search/jql`;
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Basic ${Buffer.from(`${email}:${token}`).toString(
+          "base64"
+        )}`,
+      },
+      body: JSON.stringify({
+        query: jql,
+        startAt: 0,
+        maxResults,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Jira JQL 검색 실패 (${response.status} ${response.statusText}): ${errorText}`
+      );
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Jira JQL search API 호출 중 오류:", error.message);
+    throw error;
+  }
+}
+
+// GitHub issue 번호를 Jira Epic Key로 변환
+async function resolveGitHubIssueToEpic(jira, githubIssueNumber, repoName) {
+  try {
+    const epicType = mapIssueTypeToJira("Epic");
+    const jql = `project = ${process.env.JIRA_PROJECT_KEY} AND labels = "repo:${repoName}" AND summary ~ "GitHub #${githubIssueNumber}" AND issuetype = "${epicType}"`;
+
+    console.log(`GitHub #${githubIssueNumber}를 Epic으로 검색 중...`);
+    console.log("JQL:", jql);
+
+    const result = await searchJiraIssues(jql, { maxResults: 1 });
+
+    if (result.issues && result.issues.length > 0) {
+      const epicKey = result.issues[0].key;
+      console.log(`✓ GitHub #${githubIssueNumber} → Jira Epic: ${epicKey}`);
+      return epicKey;
+    }
+
+    console.log(
+      `✗ GitHub #${githubIssueNumber}에 해당하는 Epic을 찾을 수 없음`
+    );
+    return null;
+  } catch (error) {
+    console.error(`Epic 검색 실패:`, error.message);
+    return null;
+  }
+}
+
+// Jira Epic 존재 여부 확인
+async function validateEpicExists(jira, epicKey) {
+  try {
+    console.log(`Epic ${epicKey} 존재 여부 확인 중...`);
+    const issue = await jira.getIssue(epicKey);
+
+    // Epic 타입인지 확인 (영문/한글 모두 허용)
+    const epicType = mapIssueTypeToJira("Epic");
+    const isEpic =
+      issue.fields.issuetype.name === epicType ||
+      issue.fields.issuetype.name === "Epic" ||
+      issue.fields.issuetype.name === "에픽";
+
+    if (!isEpic) {
+      console.log(
+        `✗ ${epicKey}는 Epic이 아닙니다 (타입: ${issue.fields.issuetype.name})`
+      );
+      return false;
+    }
+
+    console.log(`✓ Epic ${epicKey} 존재 확인 (${issue.fields.summary})`);
+    return true;
+  } catch (error) {
+    console.error(`✗ Epic ${epicKey} 확인 실패:`, error.message);
+    return false;
+  }
+}
+
+// Task를 Epic에 연결 (이슈 생성 후 호출)
+// Jira Cloud REST API v3 사용: parent 필드로 직접 연결 (권장 방식)
+async function linkTaskToEpic(jira, taskKey, epicKey) {
+  try {
+    console.log(`\n=== Task ${taskKey}를 Epic ${epicKey}에 연결 시작 ===`);
+
+    // 방법 1: parent 필드 사용 (Jira Cloud 권장 방식)
+    // PUT /rest/api/3/issue/{issueIdOrKey}
+    try {
+      const updateData = {
+        fields: {
+          parent: {
+            key: epicKey,
+          },
+        },
+      };
+
+      await jira.updateIssue(taskKey, updateData);
+      console.log(
+        `✅ Task ${taskKey}가 parent 필드를 통해 Epic ${epicKey}에 연결되었습니다`
+      );
+      console.log("=== Epic 연결 완료 (parent 필드 사용) ===\n");
+      return true;
+    } catch (parentError) {
+      console.log(
+        `⚠️  parent 필드 연결 실패, Epic Link 필드로 재시도: ${parentError.message}`
+      );
+
+      // 방법 2: Epic Link 커스텀 필드 사용 (레거시 방식, fallback)
+      const fields = await jira.listFields();
+      const epicLinkField = fields.find(
+        (f) =>
+          f.name === "Epic Link" ||
+          f.id === process.env.JIRA_EPIC_LINK_FIELD ||
+          f.id === "customfield_10014" // 일반적인 Epic Link 필드 ID
+      );
+
+      if (!epicLinkField) {
+        console.error("✗ Epic Link 필드를 찾을 수 없습니다");
+        console.error("✗ parent 필드와 Epic Link 필드 모두 사용 불가");
+        return false;
+      }
+
+      console.log(
+        `✓ Epic Link 필드 발견: ${epicLinkField.name} (${epicLinkField.id})`
+      );
+
+      // Epic Link 커스텀 필드로 연결
+      const epicLinkUpdateData = {
+        fields: {
+          [epicLinkField.id]: epicKey,
+        },
+      };
+
+      await jira.updateIssue(taskKey, epicLinkUpdateData);
+      console.log(
+        `✅ Task ${taskKey}가 Epic Link 필드를 통해 Epic ${epicKey}에 연결되었습니다`
+      );
+      console.log("=== Epic 연결 완료 (Epic Link 필드 사용) ===\n");
+      return true;
+    }
+  } catch (error) {
+    console.error(`❌ Epic 연결 실패:`, error.message);
+    if (error.response) {
+      console.error(
+        "응답 데이터:",
+        JSON.stringify(error.response.data, null, 2)
+      );
+    }
+    return false;
+  }
+}
+
+// Parent 이슈 처리
+async function processParentIssue(jira, issueType, issueBody, repoName) {
+  // Task 타입이 아니면 Epic Link 설정 불가
+  if (!isTaskTypeName(issueType)) {
+    return null;
+  }
+
+  // GitHub 부모 이슈 정보 (환경 변수)
+  let parentIssueNumber = process.env.GITHUB_PARENT_ISSUE_NUMBER;
+  const parentIssueTitle = process.env.GITHUB_PARENT_ISSUE_TITLE || "";
+
+  // JSON 문자열 따옴표 제거 (예: "8" → 8)
+  if (parentIssueNumber && typeof parentIssueNumber === "string") {
+    parentIssueNumber = parentIssueNumber.replace(/^["']|["']$/g, "").trim();
+  }
+
+  let epicRef = null;
+
+  // 1순위: 부모 이슈 제목에 포함된 Jira Key ([KEY-123] Title)
+  if (parentIssueTitle) {
+    const keyFromTitle = extractJiraKeyFromText(parentIssueTitle);
+    if (keyFromTitle) {
+      epicRef = keyFromTitle;
+      console.log(`✓ 부모 이슈 제목에서 Jira Epic Key 감지: ${epicRef}`);
+    }
+  }
+
+  // 2순위: GitHub 부모 이슈 번호 (Epic GitHub Issue → Jira Epic)
+  if (!epicRef && parentIssueNumber && parentIssueNumber !== "") {
+    console.log(`✓ GitHub 부모 이슈 발견: #${parentIssueNumber}`);
+    epicRef = parentIssueNumber;
+  }
+
+  if (!epicRef) {
+    // 3순위: 이슈 본문에서 Epic Link 파싱 (수동 입력)
+    epicRef = parseEpicLinkFromBody(issueBody);
+    if (!epicRef) {
+      return null;
+    }
+  }
+
+  let epicKey = epicRef;
+
+  // GitHub issue 번호 형식(숫자만)이면 Jira Epic Key로 변환
+  if (/^\d+$/.test(epicRef)) {
+    epicKey = await resolveGitHubIssueToEpic(jira, epicRef, repoName);
+    if (!epicKey) {
+      console.log(
+        `⚠️  GitHub #${epicRef}에 해당하는 Epic을 찾을 수 없어 Epic Link를 설정하지 않습니다.`
+      );
+      return null;
+    }
+  }
+
+  // Epic 존재 여부 확인
+  const epicExists = await validateEpicExists(jira, epicKey);
+  if (!epicExists) {
+    console.log(
+      `⚠️  Epic ${epicKey}가 존재하지 않거나 접근할 수 없어 Parent를 설정하지 않습니다.`
+    );
+    return null;
+  }
+
+  return { parentKey: epicKey };
+}
+
+// GitHub 이슈에서 이슈 타입 결정 (라벨 기반)
+function determineIssueType(labelsJson) {
+  try {
+    const labels = JSON.parse(labelsJson || "[]");
+    const labelNames = labels.map((l) => l.name.toLowerCase());
+
+    if (labelNames.includes("epic") || labelNames.includes("type:epic")) {
+      const epicType = mapIssueTypeToJira("Epic");
+      console.log(`라벨에서 Epic 타입 감지 → Jira: "${epicType}"`);
+      return epicType;
+    }
+
+    const taskAliases = [
+      "task",
+      "type:task",
+      "refactor",
+      "docs",
+      "doc",
+      "documentation",
+      "chore",
+      "bug",
+      "fix",
+    ];
+
+    if (taskAliases.some((alias) => labelNames.includes(alias))) {
+      const taskType = mapIssueTypeToJira("Task");
+      console.log(
+        `라벨에서 Task 계열(${taskAliases.join(
+          ", "
+        )}) 감지 → Jira: "${taskType}"`
+      );
+      return taskType;
+    }
+
+    const taskType = mapIssueTypeToJira("Task");
+    console.log(`기본 타입 사용: ${taskType} (Task)`);
+    return taskType;
+  } catch (error) {
+    console.log("이슈 타입 결정 실패, 기본 타입 사용:", error.message);
+    return mapIssueTypeToJira("Task");
+  }
+}
+
+// Jira 이슈 설명 생성
+function buildDescription() {
+  const assigneesJson = process.env.GITHUB_ISSUE_ASSIGNEES || "[]";
+  let assignees = [];
+
+  try {
+    assignees = JSON.parse(assigneesJson).map((a) => a.login);
+  } catch (error) {
+    console.log("담당자 파싱 실패:", error.message);
+  }
+
+  const sections = [];
+
+  // GitHub Issue body 추가 (있는 경우)
+  let issueBody = process.env.GITHUB_ISSUE_BODY || '';
+  if (issueBody.trim()) {
+    // GitHub 마크다운 헤더를 Jira Wiki Markup 헤더로 변환
+    issueBody = issueBody
+      .replace(/^### (.+)$/gm, 'h3. $1')  // ### → h3.
+      .replace(/^## (.+)$/gm, 'h2. $1')   // ## → h2.
+      .replace(/^# (.+)$/gm, 'h1. $1');   // # → h1.
+
+    // "No response"를 "-"로 대체
+    issueBody = issueBody.replace(/No response/gi, '-');
+
+    sections.push(issueBody.trim());
+    sections.push(""); // 구분선
+    sections.push("---");
+    sections.push(""); // 구분선
+  }
+
+  // GitHub 메타데이터
+  sections.push(`*GitHub Issue:* [#${process.env.GITHUB_ISSUE_NUMBER}|${process.env.GITHUB_ISSUE_URL}]`);
+  sections.push(`*Repository:* [${process.env.GITHUB_REPOSITORY_FULL_NAME}|${process.env.GITHUB_REPOSITORY_URL}]`);
+  sections.push(`*Created by:* [${process.env.GITHUB_ISSUE_USER}|${process.env.GITHUB_ISSUE_USER_URL}]`);
+
+  if (assignees.length > 0) {
+    sections.push("");
+    sections.push(`*GitHub Assignees:* ${assignees.join(", ")}`);
+  }
+
+  return sections.join("\n");
+}
+
+// GitHub Issue 제목에서 Jira 키 추출
+function extractJiraKeyFromTitle(title) {
+  const match = title.match(/^\[([A-Z]+-\d+)\]/);
+  return match ? match[1] : null;
+}
+
+// Jira에서 GitHub 이슈 번호로 검색
+async function findJiraIssueByGitHub(jira, githubIssueNumber, repoName) {
+  try {
+    // 1. GitHub Issue 제목에서 Jira 키 추출 시도
+    const issueTitle = process.env.GITHUB_ISSUE_TITLE || '';
+    const jiraKey = extractJiraKeyFromTitle(issueTitle);
+
+    if (jiraKey) {
+      console.log(`✓ GitHub Issue 제목에서 Jira 키 추출: ${jiraKey}`);
+
+      try {
+        const issue = await jira.findIssue(jiraKey);
+        console.log(`✓ Jira 이슈 발견: ${issue.key}`);
+        return issue;
+      } catch (error) {
+        console.log(`⚠️  Jira 키 ${jiraKey}로 이슈를 찾을 수 없음:`, error.message);
+        // Jira 키로 찾을 수 없으면 아래의 JQL 검색으로 fallback
+      }
+    }
+
+    // 2. Fallback: JQL 검색 (구버전 호환성)
+    console.log("Jira 키를 찾을 수 없어 JQL 검색을 시도합니다...");
+    const jql = `project = ${process.env.JIRA_PROJECT_KEY} AND labels = "repo:${repoName}" AND summary ~ "GitHub #${githubIssueNumber}"`;
+    console.log("Jira 검색 JQL:", jql);
+
+    const result = await searchJiraIssues(jql, { maxResults: 1 });
+
+    return result.issues && result.issues.length > 0 ? result.issues[0] : null;
+  } catch (error) {
+    console.error("Jira 검색 실패:", error.message);
+    return null;
+  }
+}
+
+// 프로젝트에서 사용 가능한 이슈 타입 조회
+async function getAvailableIssueTypes(jira) {
+  try {
+    const project = await jira.getProject(process.env.JIRA_PROJECT_KEY);
+    console.log("\n=== 사용 가능한 Jira 이슈 타입 ===");
+
+    if (project.issueTypes) {
+      project.issueTypes.forEach((type) => {
+        console.log(`  - ${type.name} (id: ${type.id})`);
+      });
+    }
+
+    return project.issueTypes || [];
+  } catch (error) {
+    console.error("⚠️  이슈 타입 조회 실패:", error.message);
+    return [];
+  }
+}
+
+// 새 이슈 생성 (opened)
+async function handleIssueOpened(jira) {
+  console.log("=== 새 Jira 이슈 생성 ===");
+
+  // 디버깅: 이슈 본문 로그
+  console.log("\n--- GitHub 이슈 본문 (처음 500자) ---");
+  const bodyPreview = (process.env.GITHUB_ISSUE_BODY || "").substring(0, 500);
+  console.log(bodyPreview);
+  console.log("--- 본문 끝 ---\n");
+
+  // 사용 가능한 이슈 타입 조회
+  const availableTypes = await getAvailableIssueTypes(jira);
+
+  const priority = determinePriority(process.env.GITHUB_ISSUE_LABELS);
+  const requestedIssueType = determineIssueType(process.env.GITHUB_ISSUE_LABELS);
+  const issueType = resolveIssueTypeName(requestedIssueType, availableTypes);
+  const description = buildDescription();
+
+  if (issueType !== requestedIssueType) {
+    console.log(
+      `\n✓ 최종 감지된 이슈 타입: ${issueType} (요청: ${requestedIssueType})`
+    );
+  } else {
+    console.log(`\n✓ 최종 감지된 이슈 타입: ${issueType}`);
+  }
+
+  const issueData = {
+    fields: {
+      project: {
+        key: process.env.JIRA_PROJECT_KEY,
+      },
+      summary: `${process.env.GITHUB_ISSUE_TITLE}`,
+      description,
+      issuetype: {
+        name: issueType,
+      },
+    },
+  };
+
+  // Assignee는 설정하지 않음 (비워둠)
+  console.log("✓ Assignee를 비워둡니다 (수동 할당 필요)");
+
+  // 에픽이 아닌 경우에만 priority 설정 (에픽은 priority가 없음)
+  if (!isEpicTypeName(issueType)) {
+    issueData.fields.priority = {
+      name: priority,
+    };
+  }
+
+  // Parent Epic 확인 (이슈 생성 후 parent 필드로 연결)
+  console.log("\n=== Parent Epic 확인 시작 ===");
+  const parentResult = await processParentIssue(
+    jira,
+    issueType,
+    process.env.GITHUB_ISSUE_BODY,
+    process.env.GITHUB_REPOSITORY_NAME
+  );
+
+  if (parentResult) {
+    console.log(
+      `✓ Parent Epic 확인: ${parentResult.parentKey} (생성 후 parent 필드로 연결 예정)`
+    );
+  } else {
+    console.log("Parent Epic 없음 - Task를 독립 이슈로 생성");
+  }
+  console.log("=== Parent Epic 확인 완료 ===\n");
+
+  console.log("생성할 이슈 데이터:", JSON.stringify(issueData, null, 2));
+
+  try {
+    const result = await jira.addNewIssue(issueData);
+    const issueTypeName = isEpicTypeName(issueType) ? "Epic" : "태스크";
+    console.log(`✅ Jira ${issueTypeName} 생성 성공: ${result.key}`);
+
+    // Parent Epic에 연결 (Task인 경우만)
+    if (parentResult) {
+      if (isTaskTypeName(issueType)) {
+        console.log(`\n=== Parent 필드로 Epic 연결 시작 ===`);
+        const linked = await linkTaskToEpic(
+          jira,
+          result.key,
+          parentResult.parentKey
+        );
+        if (!linked) {
+          console.log("⚠️  Epic 연결에 실패했지만 이슈는 생성되었습니다");
+        }
+      }
+    }
+
+    // 결과를 파일로 저장 (GitHub Actions 코멘트용)
+    const resultData = {
+      success: true,
+      jiraKey: result.key,
+      issueType: issueType,
+    };
+
+    if (parentResult) {
+      resultData.parentKey = parentResult.parentKey;
+    }
+
+    fs.writeFileSync("jira-result.json", JSON.stringify(resultData), "utf8");
+
+    return result;
+  } catch (error) {
+    console.error("❌ Jira 이슈 생성 실패:", error.message);
+    if (error.response) {
+      console.error(
+        "응답 데이터:",
+        JSON.stringify(error.response.data, null, 2)
+      );
+    }
+    throw error;
+  }
+}
+
+// 이슈 수정 (edited)
+async function handleIssueEdited(jira) {
+  console.log("=== Jira 태스크 업데이트 ===");
+
+  const jiraIssue = await findJiraIssueByGitHub(
+    jira,
+    process.env.GITHUB_ISSUE_NUMBER,
+    process.env.GITHUB_REPOSITORY_NAME
+  );
+
+  if (!jiraIssue) {
+    console.log("⚠️  대응하는 Jira 이슈를 찾을 수 없습니다.");
+    return;
+  }
+
+  console.log(`찾은 Jira 이슈: ${jiraIssue.key}`);
+
+  const issueType = jiraIssue.fields.issuetype.name;
+
+  // GitHub 제목에서 Jira 키 제거하여 순수 제목만 추출
+  let cleanTitle = process.env.GITHUB_ISSUE_TITLE;
+  const jiraKeyInTitle = cleanTitle.match(/^\[([A-Z]+-\d+)\]\s*/);
+  if (jiraKeyInTitle) {
+    cleanTitle = cleanTitle.replace(/^\[([A-Z]+-\d+)\]\s*/, '');
+  }
+
+  // GitHub Issue body를 포함한 description 생성
+  const description = buildDescription();
+
+  const updateData = {
+    fields: {
+      summary: cleanTitle,
+      description: description,
+    },
+  };
+
+  // Parent Epic 연결 처리 (Task 타입인 경우만)
+  if (isTaskTypeName(issueType)) {
+    console.log("\n=== Epic 연결 업데이트 확인 ===");
+    const parentResult = await processParentIssue(
+      jira,
+      issueType,
+      process.env.GITHUB_ISSUE_BODY,
+      process.env.GITHUB_REPOSITORY_NAME
+    );
+
+    if (parentResult) {
+      console.log(`✓ Epic 업데이트 시도: ${parentResult.parentKey}`);
+      const linked = await linkTaskToEpic(
+        jira,
+        jiraIssue.key,
+        parentResult.parentKey
+      );
+      if (!linked) {
+        console.log("⚠️  Epic 연결 업데이트 실패");
+      }
+    } else {
+      console.log("✓ Epic 연결 없음 또는 제거됨");
+    }
+    console.log("=== Epic 연결 업데이트 완료 ===\n");
+  }
+
+  try {
+    await jira.updateIssue(jiraIssue.key, updateData);
+
+    console.log(`✅ Jira 태스크 업데이트 성공: ${jiraIssue.key}`);
+
+    // GitHub Projects 상태에 따라 Jira 상태 전환
+    const projectStatus = process.env.GITHUB_PROJECT_STATUS;
+    if (projectStatus) {
+      console.log(`\n=== GitHub Projects 상태 동기화 ===`);
+      console.log(`Projects Status: ${projectStatus}`);
+
+      let jiraTransition = null;
+
+      // GitHub Projects 상태 → Jira 상태 매핑
+      switch (projectStatus) {
+        case "Todo":
+          jiraTransition = process.env.JIRA_TODO_TRANSITION_NAME || "To Do";
+          break;
+        case "In Progress":
+          jiraTransition =
+            process.env.JIRA_IN_PROGRESS_TRANSITION_NAME || "In Progress";
+          break;
+        case "Done":
+          jiraTransition = process.env.JIRA_DONE_TRANSITION_NAME || "Done";
+          break;
+        default:
+          console.log(`⚠️  매핑되지 않은 상태: ${projectStatus}`);
+      }
+
+      if (jiraTransition) {
+        const transitioned = await transitionJiraIssue(
+          jira,
+          jiraIssue.key,
+          jiraTransition
+        );
+        if (transitioned) {
+          console.log(`✅ Jira 상태 동기화 성공: ${jiraTransition}`);
+        } else {
+          console.log(`⚠️  Jira 상태 전환 실패: ${jiraTransition}`);
+        }
+      }
+
+      console.log("=== Projects 상태 동기화 완료 ===\n");
+    }
+  } catch (error) {
+    console.error("❌ Jira 태스크 업데이트 실패:", error.message);
+    throw error;
+  }
+}
+
+// Jira 이슈 상태 전환 헬퍼 함수
+async function transitionJiraIssue(jira, issueKey, targetStatusName) {
+  try {
+    // 1. 사용 가능한 전환(transition) 목록 조회
+    const transitions = await jira.listTransitions(issueKey);
+    console.log(`사용 가능한 전환: ${transitions.transitions.map((t) => t.name).join(", ")}`);
+
+    // 2. 목표 상태로 전환할 수 있는 transition 찾기
+    const targetTransition = transitions.transitions.find(
+      (t) => t.name === targetStatusName || t.to.name === targetStatusName
+    );
+
+    if (!targetTransition) {
+      console.log(
+        `⚠️  '${targetStatusName}' 전환을 찾을 수 없습니다. 사용 가능한 전환: ${transitions.transitions.map((t) => t.name).join(", ")}`
+      );
+      return false;
+    }
+
+    // 3. 전환 실행
+    await jira.transitionIssue(issueKey, {
+      transition: {
+        id: targetTransition.id,
+      },
+    });
+
+    console.log(`✅ Jira 상태 전환 성공: ${targetTransition.to.name}`);
+    return true;
+  } catch (error) {
+    console.error(`❌ Jira 상태 전환 실패:`, error.message);
+    return false;
+  }
+}
+
+// 이슈 닫기 (closed)
+async function handleIssueClosed(jira) {
+  console.log("=== GitHub 이슈 닫힘 - Jira 상태 전환 ===");
+
+  const jiraIssue = await findJiraIssueByGitHub(
+    jira,
+    process.env.GITHUB_ISSUE_NUMBER,
+    process.env.GITHUB_REPOSITORY_NAME
+  );
+
+  if (!jiraIssue) {
+    console.log("⚠️  대응하는 Jira 이슈를 찾을 수 없습니다.");
+    return;
+  }
+
+  console.log(`찾은 Jira 이슈: ${jiraIssue.key}`);
+  console.log(`현재 Jira 상태: ${jiraIssue.fields.status.name}`);
+
+  // Jira 상태를 "Done"으로 전환
+  const doneStatusName = process.env.JIRA_DONE_TRANSITION_NAME || "Done";
+  const transitioned = await transitionJiraIssue(
+    jira,
+    jiraIssue.key,
+    doneStatusName
+  );
+
+  try {
+    // 코멘트 추가
+    await jira.addComment(
+      jiraIssue.key,
+      `GitHub 이슈 [#${process.env.GITHUB_ISSUE_NUMBER}|${process.env.GITHUB_ISSUE_URL}]가 닫혔습니다.${transitioned ? `\n상태가 '${doneStatusName}'(으)로 변경되었습니다.` : ""}`
+    );
+
+    console.log(`✅ Jira 코멘트 추가 성공: ${jiraIssue.key}`);
+  } catch (error) {
+    console.error("❌ Jira 코멘트 추가 실패:", error.message);
+    throw error;
+  }
+}
+
+// 이슈 재오픈 (reopened)
+async function handleIssueReopened(jira) {
+  console.log("=== GitHub 이슈 재오픈 - Jira 상태 전환 ===");
+
+  const jiraIssue = await findJiraIssueByGitHub(
+    jira,
+    process.env.GITHUB_ISSUE_NUMBER,
+    process.env.GITHUB_REPOSITORY_NAME
+  );
+
+  if (!jiraIssue) {
+    console.log("⚠️  대응하는 Jira 이슈를 찾을 수 없습니다.");
+    return;
+  }
+
+  console.log(`찾은 Jira 이슈: ${jiraIssue.key}`);
+  console.log(`현재 Jira 상태: ${jiraIssue.fields.status.name}`);
+
+  // Jira 상태를 "To Do" 또는 "In Progress"로 전환
+  const todoStatusName =
+    process.env.JIRA_TODO_TRANSITION_NAME ||
+    process.env.JIRA_IN_PROGRESS_TRANSITION_NAME ||
+    "To Do";
+  const transitioned = await transitionJiraIssue(
+    jira,
+    jiraIssue.key,
+    todoStatusName
+  );
+
+  try {
+    // 코멘트 추가
+    await jira.addComment(
+      jiraIssue.key,
+      `GitHub 이슈 [#${process.env.GITHUB_ISSUE_NUMBER}|${process.env.GITHUB_ISSUE_URL}]가 재오픈되었습니다.${transitioned ? `\n상태가 '${todoStatusName}'(으)로 변경되었습니다.` : ""}`
+    );
+
+    console.log(`✅ Jira 코멘트 추가 성공: ${jiraIssue.key}`);
+  } catch (error) {
+    console.error("❌ Jira 코멘트 추가 실패:", error.message);
+    throw error;
+  }
+}
+
+// 라벨 변경 (labeled/unlabeled)
+async function handleLabelChanged(jira) {
+  console.log("=== GitHub 라벨 변경 - Jira Priority 업데이트 ===");
+  console.log(`Action: ${process.env.GITHUB_EVENT_ACTION}`);
+
+  const jiraIssue = await findJiraIssueByGitHub(
+    jira,
+    process.env.GITHUB_ISSUE_NUMBER,
+    process.env.GITHUB_REPOSITORY_NAME
+  );
+
+  if (!jiraIssue) {
+    console.log("⚠️  대응하는 Jira 이슈를 찾을 수 없습니다.");
+    return;
+  }
+
+  console.log(`찾은 Jira 이슈: ${jiraIssue.key}`);
+
+  // 현재 GitHub 이슈의 모든 라벨로 Priority 재계산
+  const newPriority = determinePriority(process.env.GITHUB_ISSUE_LABELS);
+  console.log(`새로운 Priority: ${newPriority}`);
+
+  // 현재 Jira 이슈의 Priority 확인
+  const currentPriority = jiraIssue.fields.priority?.name;
+  console.log(`현재 Jira Priority: ${currentPriority || "없음"}`);
+
+  if (currentPriority === newPriority) {
+    console.log("✓ Priority 변경 없음 - 업데이트 생략");
+    return;
+  }
+
+  try {
+    await jira.updateIssue(jiraIssue.key, {
+      fields: {
+        priority: { name: newPriority },
+      },
+    });
+
+    console.log(
+      `✅ Jira Priority 업데이트 성공: ${currentPriority || "없음"} → ${newPriority}`
+    );
+
+    // 변경 내용 코멘트 추가
+    await jira.addComment(
+      jiraIssue.key,
+      `GitHub 라벨 변경으로 인해 Priority가 업데이트되었습니다: ${currentPriority || "없음"} → ${newPriority}\n관련 GitHub 이슈: [#${process.env.GITHUB_ISSUE_NUMBER}|${process.env.GITHUB_ISSUE_URL}]`
+    );
+  } catch (error) {
+    console.error("❌ Jira Priority 업데이트 실패:", error.message);
+    throw error;
+  }
+}
+
+// 메인 실행
+async function main() {
+  try {
+    console.log("🚀 Jira 동기화 시작");
+    console.log("Event Action:", process.env.GITHUB_EVENT_ACTION);
+    console.log("Issue Number:", process.env.GITHUB_ISSUE_NUMBER);
+    console.log("Repository:", process.env.GITHUB_REPOSITORY_FULL_NAME);
+
+    // 환경 변수 검증
+    validateEnv();
+
+    // Jira 클라이언트 초기화
+    const jira = initJiraClient();
+
+    // 이벤트 타입별 처리
+    switch (process.env.GITHUB_EVENT_ACTION) {
+      case "opened":
+        await handleIssueOpened(jira);
+        break;
+
+      case "edited":
+        await handleIssueEdited(jira);
+        break;
+
+      case "closed":
+        await handleIssueClosed(jira);
+        break;
+
+      case "reopened":
+        await handleIssueReopened(jira);
+        break;
+
+      case "labeled":
+      case "unlabeled":
+        await handleLabelChanged(jira);
+        break;
+
+      default:
+        console.log(
+          `⚠️  처리되지 않는 이벤트: ${process.env.GITHUB_EVENT_ACTION}`
+        );
+    }
+
+    console.log("✅ Jira 동기화 완료");
+    process.exit(0);
+  } catch (error) {
+    console.error("❌ Jira 동기화 실패:", error.message);
+    console.error(error.stack);
+    process.exit(1);
+  }
+}
+
+// 스크립트 실행
+main();

--- a/.github/workflows/auto-pr-title.yml
+++ b/.github/workflows/auto-pr-title.yml
@@ -1,0 +1,73 @@
+name: Auto Add Jira Key to PR Title
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  add-jira-key:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract Jira Key from Branch and Update PR Title
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const branchName = context.payload.pull_request.head.ref;
+            const currentTitle = context.payload.pull_request.title;
+
+            console.log(`PR #${prNumber}`);
+            console.log(`Branch: ${branchName}`);
+            console.log(`Current Title: ${currentTitle}`);
+
+            // Jira 키 패턴 매칭 (예: JST-123, PROJ-456)
+            // 브랜치명에서 추출: feature/JST-123-description 또는 JST-123-fix-bug
+            const jiraKeyPattern = /([A-Z]+-\d+)/;
+            const match = branchName.match(jiraKeyPattern);
+
+            if (!match) {
+              console.log('⚠️  브랜치명에서 Jira 키를 찾을 수 없습니다.');
+              console.log('예상 형식: feature/JST-123-description 또는 JST-123-fix-bug');
+              return;
+            }
+
+            const jiraKey = match[1];
+            console.log(`✓ 추출된 Jira 키: ${jiraKey}`);
+
+            // 이미 제목에 Jira 키가 있는지 확인
+            if (currentTitle.includes(`[${jiraKey}]`)) {
+              console.log('✓ PR 제목에 이미 Jira 키가 포함되어 있습니다.');
+              return;
+            }
+
+            // Jira 키를 제목 앞에 추가
+            const newTitle = `[${jiraKey}] ${currentTitle}`;
+
+            console.log(`새 제목: ${newTitle}`);
+
+            // PR 제목 업데이트
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              title: newTitle
+            });
+
+            console.log('✅ PR 제목이 업데이트되었습니다!');
+
+            // 성공 메시지 코멘트 추가
+            const jiraHost = process.env.JIRA_HOST || 'your-domain.atlassian.net';
+            const commentBody = "🔗 **Jira 키 자동 추가 완료**\n\n" +
+              "**Jira Issue:** [" + jiraKey + "](https://" + jiraHost + "/browse/" + jiraKey + ")\n\n" +
+              "> PR 제목이 `[" + jiraKey + "]` 로 업데이트되었습니다.";
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: commentBody
+            });
+        env:
+          JIRA_HOST: ${{ secrets.JIRA_HOST }}

--- a/.github/workflows/sync-comments-to-jira.yml
+++ b/.github/workflows/sync-comments-to-jira.yml
@@ -1,0 +1,45 @@
+name: Sync GitHub Comments to Jira
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  sync-comment:
+    # PR의 코멘트는 제외 (Issue만)
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: |
+          cd .github/scripts
+          npm install
+
+      - name: Sync comment to Jira
+        env:
+          JIRA_HOST: ${{ secrets.JIRA_HOST }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
+          GITHUB_COMMENT_ID: ${{ github.event.comment.id }}
+          GITHUB_COMMENT_BODY: ${{ github.event.comment.body }}
+          GITHUB_COMMENT_USER: ${{ github.event.comment.user.login }}
+          GITHUB_COMMENT_USER_URL: ${{ github.event.comment.user.html_url }}
+          GITHUB_COMMENT_HTML_URL: ${{ github.event.comment.html_url }}
+          GITHUB_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GITHUB_ISSUE_TITLE: ${{ github.event.issue.title }}
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GITHUB_REPOSITORY_FULL_NAME: ${{ github.event.repository.full_name }}
+        run: |
+          cd .github/scripts
+          node sync-comment-to-jira.js

--- a/.github/workflows/sync-pr-to-jira.yml
+++ b/.github/workflows/sync-pr-to-jira.yml
@@ -1,0 +1,109 @@
+name: Sync PR Title to Jira
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  sync-pr-to-jira:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: |
+          cd .github/scripts
+          npm install
+
+      - name: Sync PR title to Jira
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prTitle = context.payload.pull_request.title;
+            const branchName = context.payload.pull_request.head.ref;
+
+            console.log(`PR Title: ${prTitle}`);
+            console.log(`Branch: ${branchName}`);
+
+            // Jira 키 추출 (제목 또는 브랜치명에서)
+            const jiraKeyPattern = /([A-Z]+-\d+)/;
+            let jiraKey = null;
+
+            // 1. PR 제목에서 추출 시도
+            const titleMatch = prTitle.match(/^\[([A-Z]+-\d+)\]/);
+            if (titleMatch) {
+              jiraKey = titleMatch[1];
+            } else {
+              // 2. 브랜치명에서 추출 시도
+              const branchMatch = branchName.match(jiraKeyPattern);
+              if (branchMatch) {
+                jiraKey = branchMatch[1];
+              }
+            }
+
+            if (!jiraKey) {
+              console.log('⚠️  Jira 키를 찾을 수 없습니다. PR 제목 또는 브랜치명에 Jira 키가 필요합니다.');
+              return;
+            }
+
+            console.log(`✓ 추출된 Jira 키: ${jiraKey}`);
+
+            // Jira 키를 제거한 순수 제목 추출
+            let cleanTitle = prTitle;
+            const jiraKeyInTitle = cleanTitle.match(/^\[([A-Z]+-\d+)\]\s*/);
+            if (jiraKeyInTitle) {
+              cleanTitle = cleanTitle.replace(/^\[([A-Z]+-\d+)\]\s*/, '');
+            }
+
+            console.log(`Clean Title: ${cleanTitle}`);
+
+            // 환경 변수로 전달
+            const fs = require('fs');
+            fs.appendFileSync(process.env.GITHUB_ENV, `JIRA_KEY=${jiraKey}\n`);
+            fs.appendFileSync(process.env.GITHUB_ENV, `CLEAN_TITLE=${cleanTitle}\n`);
+
+      - name: Update Jira issue title
+        if: env.JIRA_KEY != ''
+        env:
+          JIRA_HOST: ${{ secrets.JIRA_HOST }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          cd .github/scripts
+          node -e "
+          const JiraClient = require('jira-client');
+
+          const jira = new JiraClient({
+            protocol: 'https',
+            host: process.env.JIRA_HOST,
+            username: process.env.JIRA_EMAIL,
+            password: process.env.JIRA_API_TOKEN,
+            apiVersion: '2',
+            strictSSL: true
+          });
+
+          const jiraKey = process.env.JIRA_KEY;
+          const cleanTitle = process.env.CLEAN_TITLE;
+
+          console.log(\`Updating Jira issue \${jiraKey} with title: \${cleanTitle}\`);
+
+          jira.updateIssue(jiraKey, {
+            fields: {
+              summary: cleanTitle
+            }
+          })
+          .then(() => {
+            console.log(\`✅ Jira issue \${jiraKey} title updated successfully\`);
+          })
+          .catch(error => {
+            console.error(\`❌ Failed to update Jira issue: \${error.message}\`);
+            process.exit(1);
+          });
+          "

--- a/.github/workflows/sync-to-jira.yml
+++ b/.github/workflows/sync-to-jira.yml
@@ -1,0 +1,509 @@
+name: Sync GitHub Issues to Jira
+
+on:
+  issues:
+    types: [opened, edited, closed, reopened, labeled, unlabeled]
+
+jobs:
+  sync-to-jira:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: |
+          cd .github/scripts
+          npm install
+
+      - name: Ensure workflow labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('::group::📝 Label Management');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const labels = [
+              { name: 'Task', color: '0EA5E9', description: 'Generic task label (sky blue)' },
+              { name: 'Epic', color: 'A855F7', description: 'Jira Epic sync label (vibrant purple)' },
+              { name: 'refactor', color: 'F59E0B', description: 'Code or architecture clean-up (amber)' },
+              { name: 'docs', color: '10B981', description: 'Documentation updates (emerald)' },
+              { name: 'chore', color: '8B5CF6', description: 'Maintenance or ops work (violet)' },
+              { name: 'bug', color: 'EF4444', description: 'Defects mapped to Jira Task (bright red)' },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label.name });
+                await github.rest.issues.updateLabel({
+                  owner,
+                  repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+                console.log(`::notice::✓ Label '${label.name}' updated`);
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description
+                  });
+                  console.log(`::notice::✓ Label '${label.name}' created`);
+                } else {
+                  console.log(`::error::Failed to manage label '${label.name}': ${error.message}`);
+                  throw error;
+                }
+              }
+            }
+
+            console.log('::endgroup::');
+
+      - name: Auto-assign issue creator
+        if: github.event.action == 'opened'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const creator = context.payload.issue.user.login;
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              assignees: [creator]
+            });
+
+            console.log(`::notice::✓ Auto-assigned issue #${issueNumber} to @${creator}`);
+
+      - name: Get GitHub Projects status
+        if: github.event.action != 'closed'
+        id: project_status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('::group::🗂️ GitHub Projects Status');
+
+            const issueNumber = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const projectName = 'ddcn41-v3';
+
+            try {
+              // 프로젝트 조회
+              const projectQuery = `
+                query($owner: String!, $repo: String!, $projectName: String!) {
+                  repository(owner: $owner, name: $repo) {
+                    projectsV2(first: 10, query: $projectName) {
+                      nodes {
+                        id
+                        title
+                        fields(first: 20) {
+                          nodes {
+                            ... on ProjectV2Field {
+                              id
+                              name
+                            }
+                            ... on ProjectV2SingleSelectField {
+                              id
+                              name
+                              options {
+                                id
+                                name
+                              }
+                            }
+                          }
+                        }
+                        items(first: 100) {
+                          nodes {
+                            id
+                            content {
+                              ... on Issue {
+                                number
+                              }
+                            }
+                            fieldValues(first: 20) {
+                              nodes {
+                                ... on ProjectV2ItemFieldSingleSelectValue {
+                                  name
+                                  field {
+                                    ... on ProjectV2SingleSelectField {
+                                      name
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `;
+
+              const projectData = await github.graphql(projectQuery, {
+                owner,
+                repo,
+                projectName
+              });
+
+              const project = projectData.repository.projectsV2.nodes.find(p => p.title === projectName);
+              if (!project) {
+                console.log('::warning::Project not found');
+                console.log('::endgroup::');
+                return null;
+              }
+
+              // 현재 이슈의 프로젝트 아이템 찾기
+              const item = project.items.nodes.find(
+                node => node.content?.number === issueNumber
+              );
+
+              if (!item) {
+                console.log('::notice::Issue not in project');
+                console.log('::endgroup::');
+                return null;
+              }
+
+              // Status 필드 값 찾기
+              const statusValue = item.fieldValues.nodes.find(
+                fv => fv.field?.name === 'Status'
+              );
+
+              if (statusValue) {
+                console.log(`::notice::✓ Project Status: ${statusValue.name}`);
+                console.log('::endgroup::');
+                return { status: statusValue.name };
+              }
+
+              console.log('::endgroup::');
+              return null;
+            } catch (error) {
+              console.log(`::error::Failed to query project status: ${error.message}`);
+              console.log('::endgroup::');
+              return null;
+            }
+
+      - name: Get parent issue info
+        if: github.event.action != 'closed'
+        id: parent_issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('::group::🔗 Parent Issue Detection');
+
+            const issueNumber = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            try {
+              // GitHub GraphQL로 부모 이슈 정보 조회 (sub-issues API 사용)
+              const query = `
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    issue(number: $number) {
+                      parent {
+                        number
+                        title
+                      }
+                    }
+                  }
+                }
+              `;
+
+              const result = await github.graphql(query, {
+                owner,
+                repo,
+                number: issueNumber,
+                headers: {
+                  'GraphQL-Features': 'sub_issues'
+                }
+              });
+
+              const parent = result.repository.issue.parent;
+
+              if (parent && parent.number) {
+                console.log(`::notice::✓ Parent issue found: #${parent.number} - ${parent.title}`);
+                console.log('::endgroup::');
+                return {
+                  number: parent.number,
+                  title: parent.title || ''
+                };
+              } else {
+                console.log('::notice::No parent issue');
+                console.log('::endgroup::');
+                return null;
+              }
+            } catch (error) {
+              console.log(`::error::Failed to query parent issue: ${error.message}`);
+              console.log('::endgroup::');
+              return null;
+            }
+
+      - name: Sync issue to Jira
+        env:
+          JIRA_HOST: ${{ secrets.JIRA_HOST }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
+          JIRA_ISSUE_TYPE: ${{ vars.JIRA_ISSUE_TYPE || 'Task' }}
+          JIRA_DEFAULT_PRIORITY: ${{ vars.JIRA_DEFAULT_PRIORITY || 'Medium' }}
+          JIRA_EPIC_LINK_FIELD: ${{ vars.JIRA_EPIC_LINK_FIELD || 'customfield_10014' }}
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
+          GITHUB_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GITHUB_ISSUE_TITLE: ${{ github.event.issue.title }}
+          GITHUB_ISSUE_BODY: ${{ github.event.issue.body }}
+          GITHUB_ISSUE_URL: ${{ github.event.issue.html_url }}
+          GITHUB_ISSUE_STATE: ${{ github.event.issue.state }}
+          GITHUB_ISSUE_LABELS: ${{ toJSON(github.event.issue.labels) }}
+          GITHUB_ISSUE_ASSIGNEES: ${{ toJSON(github.event.issue.assignees) }}
+          GITHUB_ISSUE_USER: ${{ github.event.issue.user.login }}
+          GITHUB_ISSUE_USER_URL: ${{ github.event.issue.user.html_url }}
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GITHUB_REPOSITORY_FULL_NAME: ${{ github.event.repository.full_name }}
+          GITHUB_REPOSITORY_URL: ${{ github.event.repository.html_url }}
+          GITHUB_PARENT_ISSUE_NUMBER: ${{ fromJSON(steps.parent_issue.outputs.result || '{}').number || '' }}
+          GITHUB_PARENT_ISSUE_TITLE: ${{ fromJSON(steps.parent_issue.outputs.result || '{}').title || '' }}
+          GITHUB_PROJECT_STATUS: ${{ fromJSON(steps.project_status.outputs.result || '{}').status || '' }}
+        run: |
+          cd .github/scripts
+          node sync-jira.js
+
+      - name: Update issue title and add comment
+        if: github.event.action == 'opened'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('::group::📝 GitHub Issue Update');
+
+            const fs = require('fs');
+            try {
+              const result = fs.readFileSync('.github/scripts/jira-result.json', 'utf8');
+              const data = JSON.parse(result);
+
+              if (data.success && data.jiraKey) {
+                // GitHub 이슈 제목 업데이트
+                const currentTitle = context.payload.issue.title;
+                const newTitle = `[${data.jiraKey}] ${currentTitle}`;
+
+                await github.rest.issues.update({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: newTitle
+                });
+
+                console.log(`::notice::✓ Issue title updated: ${newTitle}`);
+
+                // 이슈 타입별 메시지
+                const issueTypeKo = {
+                  'Epic': 'Epic',
+                  'Story': '스토리',
+                  'Bug': '버그',
+                  'Task': '태스크'
+                };
+                const typeName = issueTypeKo[data.issueType] || '태스크';
+                const emoji = data.issueType === 'Epic' ? '🎯' :
+                              data.issueType === 'Bug' ? '🐛' :
+                              data.issueType === 'Story' ? '📖' : '✅';
+
+                // 코멘트 본문 생성
+                let commentBody = emoji + " **Jira " + typeName + " 동기화 완료**\n\n";
+                commentBody += "**Jira Ticket:** [" + data.jiraKey + "](https://" + process.env.JIRA_HOST + "/browse/" + data.jiraKey + ")\n";
+
+                // Parent 정보 추가
+                if (data.parentKey) {
+                  commentBody += "**상위 Epic:** [" + data.parentKey + "](https://" + process.env.JIRA_HOST + "/browse/" + data.parentKey + ")\n";
+                }
+
+                commentBody += "\n> GitHub Issue 제목이 `[" + data.jiraKey + "]` 로 업데이트되었습니다.";
+
+                // 코멘트 추가
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+                });
+
+                console.log(`::notice::✓ Comment added with Jira sync info`);
+                console.log(`::notice::Issue type: ${data.issueType}`);
+              }
+
+              console.log('::endgroup::');
+            } catch (error) {
+              console.log(`::error::Failed to update issue: ${error.message}`);
+              console.log('::endgroup::');
+            }
+        env:
+          JIRA_HOST: ${{ secrets.JIRA_HOST }}
+
+      - name: Set GitHub Project custom fields
+        if: github.event.action == 'opened'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('::group::🗂️ GitHub Project Fields');
+
+            // GitHub Projects v2 커스텀 필드 설정
+            const projectName = 'ddcn41-v3';
+            const issueNumber = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            try {
+              // 1. 프로젝트 ID 조회
+              const projectQuery = `
+                query($owner: String!, $repo: String!, $projectName: String!) {
+                  repository(owner: $owner, name: $repo) {
+                    projectsV2(first: 10, query: $projectName) {
+                      nodes {
+                        id
+                        title
+                        fields(first: 20) {
+                          nodes {
+                            ... on ProjectV2Field {
+                              id
+                              name
+                            }
+                            ... on ProjectV2SingleSelectField {
+                              id
+                              name
+                              options {
+                                id
+                                name
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `;
+
+              const projectData = await github.graphql(projectQuery, {
+                owner,
+                repo,
+                projectName
+              });
+
+              const project = projectData.repository.projectsV2.nodes.find(p => p.title === projectName);
+
+              if (!project) {
+                console.log(`::warning::Project '${projectName}' not found`);
+                console.log('::endgroup::');
+                return;
+              }
+
+              console.log(`::notice::✓ Project found: ${project.title}`);
+
+              // 2. Issue를 프로젝트에 추가
+              const issueId = context.payload.issue.node_id;
+
+              const addItemMutation = `
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: {
+                    projectId: $projectId
+                    contentId: $contentId
+                  }) {
+                    item {
+                      id
+                    }
+                  }
+                }
+              `;
+
+              const addResult = await github.graphql(addItemMutation, {
+                projectId: project.id,
+                contentId: issueId
+              });
+
+              const itemId = addResult.addProjectV2ItemById.item.id;
+              console.log(`::notice::✓ Issue added to project`);
+
+              // 3. 커스텀 필드 설정
+              const fields = project.fields.nodes;
+
+              // Status 필드 - "Todo"로 설정
+              const statusField = fields.find(f => f.name === 'Status');
+              if (statusField) {
+                const todoOption = statusField.options?.find(o => o.name === 'Todo');
+                if (todoOption) {
+                  const updateStatusMutation = `
+                    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+                      updateProjectV2ItemFieldValue(input: {
+                        projectId: $projectId
+                        itemId: $itemId
+                        fieldId: $fieldId
+                        value: $value
+                      }) {
+                        projectV2Item {
+                          id
+                        }
+                      }
+                    }
+                  `;
+
+                  await github.graphql(updateStatusMutation, {
+                    projectId: project.id,
+                    itemId,
+                    fieldId: statusField.id,
+                    value: { singleSelectOptionId: todoOption.id }
+                  });
+
+                  console.log(`::notice::✓ Status set to: Todo`);
+                }
+              }
+
+              // Start date 필드 - 오늘 날짜로 설정
+              const startDateField = fields.find(f => f.name === 'Start date');
+              if (startDateField) {
+                const today = new Date().toISOString().split('T')[0];
+
+                const updateDateMutation = `
+                  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+                    updateProjectV2ItemFieldValue(input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: $value
+                    }) {
+                      projectV2Item {
+                        id
+                      }
+                    }
+                  }
+                `;
+
+                await github.graphql(updateDateMutation, {
+                  projectId: project.id,
+                  itemId,
+                  fieldId: startDateField.id,
+                  value: { date: today }
+                });
+
+                console.log(`::notice::✓ Start date set to: ${today}`);
+              }
+
+              console.log('::endgroup::');
+
+            } catch (error) {
+              console.log(`::error::Failed to set project fields: ${error.message}`);
+              if (error.data) {
+                console.log(`::debug::${JSON.stringify(error.data, null, 2)}`);
+              }
+              console.log('::endgroup::');
+              // 에러가 발생해도 워크플로우는 계속 진행
+            }


### PR DESCRIPTION
### PR 타입

FEATURE : 새로운 기능 추가

### 반영 브랜치

feat/[CLD-1]

### 변경 사항
- 이슈 생성시
    - 이슈 제목에 지라 티켓 아이디 자동 추가
    - Assignees 자동 할당
    - 프로젝트 추가 및 Status =Todo
- 이슈 변경시
    - 제목, Description 변경시 Jira로 단방향 동기화 가능
    - 깃헙 이슈 closed -> Jira 티켓 Done 으로 상태 변경
- 에픽의 서브 이슈 생성시
    - Jira에서도 하위 업무로 설정
- PR 생성시
    - PR 제목에 지라 티켓 아이디 자동 추가



### 테스트 결과
<img width="1455" height="1106" alt="image" src="https://github.com/user-attachments/assets/5470c18b-4552-43ca-98ea-c5e6611aade1" />


[CLD-1]: https://ddcn41.atlassian.net/browse/CLD-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ